### PR TITLE
Fix null reference if the interpolate plugin does not already exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,16 +9,11 @@ module.exports = {
         d => d.replacements && d.replacements.NODE_ENV
       );
 
-      if (!originInterpolatePlugin) {
-        console.warn('Could not find react-dev-utils/InterpolateHtmlPlugin.');
-      }
+      const interpolatePlugin =
+        (originInterpolatePlugin && originInterpolatePlugin.htmlWebpackPlugin) ||
+        require('html-webpack-plugin');
 
-      webpackConfig.plugins.push(
-        new InterpolateHtmlPlugin(
-          originInterpolatePlugin.htmlWebpackPlugin || require('html-webpack-plugin'),
-          pluginOptions
-        )
-      );
+      webpackConfig.plugins.push(new InterpolateHtmlPlugin(interpolatePlugin, pluginOptions));
     } else {
       throw new Error('The craco-interpolate-html plugin is available only for object options');
     }


### PR DESCRIPTION
This PR fixes the possibility of a null reference exception if the webpack config does not already have an instance of the `InterpolateHtmlPlugin` installed as documented in issue https://github.com/kkulbae/craco-interpolate-html-plugin/issues/1.

This scenario is made more likely by issue https://github.com/gsoft-inc/craco/issues/244 in the @craco/craco proper repo.